### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A Model Context Protocol (MCP) server that provides seamless integration with [Coroot](https://coroot.com) observability platform. This server enables MCP clients to monitor applications, analyze performance metrics, examine logs and traces, and manage infrastructure through Coroot's comprehensive API.
 
+<a href="https://glama.ai/mcp/servers/@jamesbrink/mcp-coroot">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jamesbrink/mcp-coroot/badge" alt="Server for Coroot MCP server" />
+</a>
+
 ## Getting Started
 
 Add this configuration to your MCP client settings:


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for Coroot](https://glama.ai/mcp/servers/@jamesbrink/mcp-coroot) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jamesbrink/mcp-coroot">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jamesbrink/mcp-coroot/badge" alt="Server for Coroot MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.